### PR TITLE
Permission check fails when running with Security Manager

### DIFF
--- a/implementation/cdi/src/main/java/io/smallrye/opentelemetry/implementation/cdi/OpenTelemetryProducer.java
+++ b/implementation/cdi/src/main/java/io/smallrye/opentelemetry/implementation/cdi/OpenTelemetryProducer.java
@@ -2,6 +2,8 @@ package io.smallrye.opentelemetry.implementation.cdi;
 
 import static io.smallrye.opentelemetry.api.OpenTelemetryConfig.INSTRUMENTATION_NAME;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +48,11 @@ public class OpenTelemetryProducer {
             builder.setServiceClassLoader(contextClassLoader);
         }
 
+        return (System.getSecurityManager() == null) ? getOpenTelemetrySdk(builder)
+                : AccessController.doPrivileged((PrivilegedAction<OpenTelemetry>) () -> getOpenTelemetrySdk(builder));
+    }
+
+    private OpenTelemetrySdk getOpenTelemetrySdk(AutoConfiguredOpenTelemetrySdkBuilder builder) {
         return builder
                 .disableShutdownHook()
                 .addPropertiesSupplier(() -> config.properties())


### PR DESCRIPTION
Fixes https://github.com/smallrye/smallrye-opentelemetry/issues/271

If SM is enabled, create SDK in doPrivileged. Otherwise, behave as normal.