### PR TITLE
[Enhancement] Tries to inject Vertx instance from CDI using a qualifier

### DIFF
--- a/implementation/exporters/pom.xml
+++ b/implementation/exporters/pom.xml
@@ -16,6 +16,10 @@
             <groupId>io.smallrye.reactive</groupId>
             <artifactId>mutiny</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-annotation</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.smallrye.opentelemetry</groupId>
@@ -37,6 +41,11 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <version.microprofile.opentelemetry>2.0</version.microprofile.opentelemetry>
         <version.microprofile.config>3.1</version.microprofile.config>
         <version.mutiny>2.6.2</version.mutiny>
+        <version.smallrye.common>2.5.0</version.smallrye.common>
         <version.resteasy>6.2.10.Final</version.resteasy>
         <version.vertx.grpc>4.5.10</version.vertx.grpc>
         <micrometer.version>1.13.4</micrometer.version>
@@ -84,6 +85,11 @@
                 <groupId>io.smallrye.reactive</groupId>
                 <artifactId>mutiny</artifactId>
                 <version>${version.mutiny}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.common</groupId>
+                <artifactId>smallrye-common-annotation</artifactId>
+                <version>${version.smallrye.common}</version>
             </dependency>
 
             <!-- Micrometer Core and Registries, imported as BOM -->


### PR DESCRIPTION
Fixes #380 

This PR tries to add a new config `otel.exporter.vertx.cdi.identifier` to tries to inject the Vertx instance from the CDI with the qualifier, and it falls back to current way of `Vertx.vertx()` if there is no such configuration to keep compatible.