### PR TITLE
Fix default values in microprofile-config.properties

### DIFF
--- a/implementation/config/src/main/resources/META-INF/microprofile-config.properties
+++ b/implementation/config/src/main/resources/META-INF/microprofile-config.properties
@@ -19,9 +19,9 @@ otel.exporter.otlp.protocol=grpc
 otel.exporter.otlp.endpoint=http://localhost:4317
 otel.exporter.otlp.compression=gzip
 otel.exporter.otlp.timeout=10000
-otel.exporter.otlp.metrics.temporality.preference=CUMULATIVE
-otel.exporter.otlp.metrics.default.histogram.aggregation=EXPLICIT_BUCKET_HISTOGRAM
-otel.metrics.exemplar.filter=TRACE_BASED
+otel.exporter.otlp.metrics.temporality.preference=cumulative
+otel.exporter.otlp.metrics.default.histogram.aggregation=explicit_bucket_histogram
+otel.metrics.exemplar.filter=trace_based
 
 otel.blrp.schedule.delay=1000
 otel.blrp.max.queue.size=512


### PR DESCRIPTION
Various config readers (notably, `AbstractVertxExporterProvider`) read config values in a case sensitive manner. All the OpenTelemetry config values are supposed to be lower-case, so this commit changes the default values in `microprofile-config.properties` to also be lower-case.