### PR TITLE
SROTEL-428 - LogRecordExporter is created using incorrect service name

### DIFF
--- a/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/logs/VertxLogsExporterProvider.java
+++ b/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/logs/VertxLogsExporterProvider.java
@@ -26,7 +26,7 @@ public class VertxLogsExporterProvider extends AbstractVertxExporterProvider<Log
             final String protocol = getProtocol(config, getSignalType());
 
             if (PROTOCOL_GRPC.equals(protocol)) {
-                return new VertxGrpcLogsExporter(createGrpcExporter(config, VertxGrpcSender.GRPC_TRACE_SERVICE_NAME));
+                return new VertxGrpcLogsExporter(createGrpcExporter(config, VertxGrpcSender.GRPC_LOG_SERVICE_NAME));
             } else if (PROTOCOL_HTTP_PROTOBUF.equals(protocol)) {
                 return new VertxHttpLogsExporter(createHttpExporter(config, VertxHttpSender.LOGS_PATH));
             } else {

--- a/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/sender/VertxGrpcSender.java
+++ b/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/sender/VertxGrpcSender.java
@@ -40,6 +40,7 @@ public final class VertxGrpcSender<T extends Marshaler> implements GrpcSender<T>
 
     public static final String GRPC_TRACE_SERVICE_NAME = "opentelemetry.proto.collector.trace.v1.TraceService";
     public static final String GRPC_METRIC_SERVICE_NAME = "opentelemetry.proto.collector.metrics.v1.MetricsService";
+    public static final String GRPC_LOG_SERVICE_NAME = "opentelemetry.proto.collector.logs.v1.LogsService";
     private static final String GRPC_METHOD_NAME = "Export";
 
     private static final String GRPC_STATUS = "grpc-status";


### PR DESCRIPTION
Add constant for log service name
Update LogRecordExporter creation to use correct service name

Resolves #428 