### PR TITLE
SROTEL-524 - Log Handler can be installed twice

### DIFF
--- a/testsuite/extra/src/test/java/io/smallrye/opentelemetry/extra/test/logs/LogsTest.java
+++ b/testsuite/extra/src/test/java/io/smallrye/opentelemetry/extra/test/logs/LogsTest.java
@@ -1,38 +1,54 @@
 package io.smallrye.opentelemetry.extra.test.logs;
 
-import static io.restassured.RestAssured.given;
-import static java.net.HttpURLConnection.HTTP_OK;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.List;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.logging.Level;
+import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
 import jakarta.inject.Inject;
-import jakarta.ws.rs.ApplicationPath;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.core.Application;
-import jakarta.ws.rs.core.Response;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Value;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.smallrye.opentelemetry.api.OpenTelemetryConfig;
+import io.smallrye.opentelemetry.api.OpenTelemetryLogHandler;
+import io.smallrye.opentelemetry.implementation.cdi.OpenTelemetryProducer;
 import io.smallrye.opentelemetry.test.InMemoryExporter;
 
 @ExtendWith(ArquillianExtension.class)
 public class LogsTest {
     @Inject
     InMemoryExporter logExporter;
+
+    @Inject
+    OpenTelemetry openTelemetry;
+
+    @Inject
+    OpenTelemetryConfig config;
+
+    @BeforeAll
+    public static void setup() {
+        var rootLogger = LogManager.getLogManager().getLogger("");
+
+        Arrays.stream(rootLogger.getHandlers()).filter(h -> h instanceof OpenTelemetryLogHandler)
+                .findFirst()
+                .ifPresent(rootLogger::removeHandler);
+    }
 
     @Deployment
     public static WebArchive createDeployment() {
@@ -46,39 +62,30 @@ public class LogsTest {
     }
 
     @Test
-    void exporter() {
-        assertNotNull(logExporter);
+    void testLogMessageFormatting() throws InterruptedException {
+        Logger logger = Logger.getLogger(getClass().getName());
+        logger.log(Level.INFO, "Test %s", "message");
+
+        logExporter.assertFinishedLogRecordItems(items -> assertTrue(items.stream().anyMatch(r -> {
+            var value = r.getBodyValue();
+            return value != null && value.asString().contains("Test message");
+        }), "Log message not found"),
+                Duration.ofSeconds(60));
     }
 
     @Test
-    void logMessage() throws InterruptedException {
-        given().get("/log").then().statusCode(HTTP_OK);
+    void testDuplicatedMessages() throws InterruptedException {
+        // Create another instance to simulate multiple deployments in the same JVM
+        new OpenTelemetryProducer().getOpenTelemetry(config);
 
-        List<LogRecordData> items = logExporter.getFinishedLogRecordItems(1);
+        final String testMessage = "Should not be duplicated";
+        Logger.getLogger(getClass().getName()).log(Level.INFO, testMessage);
 
-        assertTrue(items.stream().anyMatch(r -> {
-            var value = r.getBodyValue();
-            return value != null && value.asString().contains("Test message");
-        }), "Log message not found");
-    }
-
-    @Path("/")
-    public static class LogResource {
-        private static final Logger logger = Logger.getLogger(LogResource.class.getName());
-
-        @Inject
-        Tracer tracer;
-
-        @GET
-        @Path("/log")
-        public Response log() {
-            logger.log(Level.INFO, "Test %s", "message");
-            return Response.ok().build();
-        }
-    }
-
-    @ApplicationPath("/")
-    public static class RestApplication extends Application {
-
+        logExporter.assertFinishedLogRecordItems(items -> assertEquals(1, items.stream().map(LogRecordData::getBodyValue)
+                .filter(Objects::nonNull)
+                .map(Value::asString)
+                .filter(s -> s.equals(testMessage))
+                .count(), "Duplicated log message found"),
+                Duration.ofSeconds(5));
     }
 }


### PR DESCRIPTION
- Modify OpenTelemetryLogHandler.install to check for existing handler 
- Simplify log test by removing Jakarta Rest application 
- Add test for duplicated log entry
- Add helper method to InMemoryExporter

Resolves #524 