### PR TITLE
SR OpenTelemetry with independent senders 

### DIFF
--- a/implementation/cdi/src/main/java/io/smallrye/opentelemetry/implementation/cdi/OpenTelemetryProducer.java
+++ b/implementation/cdi/src/main/java/io/smallrye/opentelemetry/implementation/cdi/OpenTelemetryProducer.java
@@ -28,11 +28,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.Classes;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.Cpu;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.GarbageCollector;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.MemoryPools;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.Threads;
+import io.opentelemetry.instrumentation.runtimemetrics.java8.RuntimeMetrics;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
@@ -66,27 +62,15 @@ public class OpenTelemetryProducer {
 
         OpenTelemetry openTelemetry = otelSdk.getOpenTelemetrySdk();
 
-        closeables.addAll(Classes.registerObservers(openTelemetry));
-
-        List<AutoCloseable> cpuObservers;
-        List<AutoCloseable> garbageCollectorObservers;
-
+        RuntimeMetrics runtimeMetrics;
         if (System.getSecurityManager() == null) {
-            cpuObservers = Cpu.registerObservers(openTelemetry);
-            garbageCollectorObservers = GarbageCollector.registerObservers(openTelemetry);
+            runtimeMetrics = RuntimeMetrics.create(openTelemetry);
         } else {
             // Requires FilePermission/RuntimePermission/ManagementPermission
-            cpuObservers = AccessController.doPrivileged(
-                    (PrivilegedAction<List<AutoCloseable>>) () -> Cpu.registerObservers(openTelemetry));
-            // Requires FilePermission/RuntimePermission
-            garbageCollectorObservers = AccessController.doPrivileged(
-                    (PrivilegedAction<List<AutoCloseable>>) () -> GarbageCollector.registerObservers(openTelemetry));
+            runtimeMetrics = AccessController.doPrivileged(
+                    (PrivilegedAction<RuntimeMetrics>) () -> RuntimeMetrics.create(openTelemetry));
         }
-
-        closeables.addAll(cpuObservers);
-        closeables.addAll(garbageCollectorObservers);
-        closeables.addAll(MemoryPools.registerObservers(openTelemetry));
-        closeables.addAll(Threads.registerObservers(openTelemetry));
+        closeables.add(runtimeMetrics);
 
         if (System.getSecurityManager() == null) {
             OpenTelemetryLogHandler.install(openTelemetry);

--- a/implementation/cdi/src/main/java/io/smallrye/opentelemetry/implementation/cdi/WithSpanInterceptor.java
+++ b/implementation/cdi/src/main/java/io/smallrye/opentelemetry/implementation/cdi/WithSpanInterceptor.java
@@ -17,10 +17,10 @@ import io.opentelemetry.instrumentation.annotations.SpanAttribute;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.opentelemetry.instrumentation.api.annotation.support.MethodSpanAttributesExtractor;
 import io.opentelemetry.instrumentation.api.annotation.support.ParameterAttributeNamesExtractor;
-import io.opentelemetry.instrumentation.api.incubator.semconv.util.SpanNames;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
+import io.opentelemetry.instrumentation.api.semconv.util.SpanNames;
 
 public class WithSpanInterceptor {
     private final Instrumenter<MethodRequest, Void> instrumenter;

--- a/implementation/exporters/pom.xml
+++ b/implementation/exporters/pom.xml
@@ -13,12 +13,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>mutiny</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.smallrye.common</groupId>
-            <artifactId>smallrye-common-annotation</artifactId>
+            <groupId>io.smallrye.opentelemetry</groupId>
+            <artifactId>smallrye-opentelemetry-senders</artifactId>
         </dependency>
 
         <dependency>
@@ -28,19 +24,11 @@
 
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-common</artifactId>
+            <artifactId>opentelemetry-exporter-otlp-common</artifactId>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.vertx</groupId>
-            <artifactId>vertx-grpc-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-otlp-common</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.enterprise</groupId>

--- a/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/AbstractVertxExporterProvider.java
+++ b/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/AbstractVertxExporterProvider.java
@@ -18,17 +18,15 @@ import java.util.logging.Logger;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.CDI;
 
-import io.opentelemetry.api.metrics.MeterProvider;
-import io.opentelemetry.exporter.internal.grpc.GrpcExporter;
-import io.opentelemetry.exporter.internal.http.HttpExporter;
-import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
+import io.opentelemetry.sdk.common.export.GrpcSender;
+import io.opentelemetry.sdk.common.export.HttpSender;
 import io.smallrye.common.annotation.Identifier;
-import io.smallrye.opentelemetry.implementation.exporters.sender.VertxGrpcSender;
-import io.smallrye.opentelemetry.implementation.exporters.sender.VertxHttpSender;
+import io.smallrye.opentelemetry.senders.VertxGrpcSender;
+import io.smallrye.opentelemetry.senders.VertxHttpSender;
 import io.vertx.core.Vertx;
 
-public abstract class AbstractVertxExporterProvider<T extends Marshaler> {
+public abstract class AbstractVertxExporterProvider {
     private final String signalType;
     private final String exporterName;
 
@@ -45,15 +43,6 @@ public abstract class AbstractVertxExporterProvider<T extends Marshaler> {
 
     protected String getSignalType() {
         return signalType;
-    }
-
-    protected GrpcExporter<T> createGrpcExporter(ConfigProperties config, String grpcEndpointPath) throws URISyntaxException {
-        return new GrpcExporter<>(getName(), getSignalType(), createGrpcSender(config, grpcEndpointPath), MeterProvider::noop);
-    }
-
-    protected HttpExporter<T> createHttpExporter(ConfigProperties config, String httpEndpointPath) throws URISyntaxException {
-        return new HttpExporter<>(getName(), getSignalType(), createHttpSender(config, httpEndpointPath), MeterProvider::noop,
-                false);//TODO: this will be enhanced in the future
     }
 
     /**
@@ -76,10 +65,9 @@ public abstract class AbstractVertxExporterProvider<T extends Marshaler> {
         return Vertx.vertx();
     }
 
-    protected VertxGrpcSender<T> createGrpcSender(ConfigProperties config, String grpcEndpointPath) throws URISyntaxException {
+    protected GrpcSender createGrpcSender(ConfigProperties config, String grpcEndpointPath) throws URISyntaxException {
         URI baseUri = new URI(getOtlpEndpoint(config, OTLP_GRPC_ENDPOINT, signalType));
-        return new VertxGrpcSender<>(
-                signalType,
+        return new VertxGrpcSender(
                 baseUri,
                 grpcEndpointPath,
                 getCompression(config, signalType),
@@ -89,7 +77,7 @@ public abstract class AbstractVertxExporterProvider<T extends Marshaler> {
                 getVertx(config));
     }
 
-    protected VertxHttpSender createHttpSender(ConfigProperties config, String httpEndpointPath) throws URISyntaxException {
+    protected HttpSender createHttpSender(ConfigProperties config, String httpEndpointPath) throws URISyntaxException {
         URI baseUri = new URI(getOtlpEndpoint(config, OTLP_HTTP_PROTOBUF_ENDPOINT, signalType));
         return new VertxHttpSender(
                 baseUri,

--- a/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/logs/VertxGrpcLogsExporter.java
+++ b/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/logs/VertxGrpcLogsExporter.java
@@ -2,22 +2,34 @@ package io.smallrye.opentelemetry.implementation.exporters.logs;
 
 import java.util.Collection;
 
-import io.opentelemetry.exporter.internal.grpc.GrpcExporter;
 import io.opentelemetry.exporter.internal.otlp.logs.LogsRequestMarshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.export.GrpcSender;
+import io.opentelemetry.sdk.common.export.GrpcStatusCode;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 
 public class VertxGrpcLogsExporter implements LogRecordExporter {
-    private final GrpcExporter<LogsRequestMarshaler> delegate;
+    private final GrpcSender sender;
 
-    public VertxGrpcLogsExporter(GrpcExporter<LogsRequestMarshaler> delegate) {
-        this.delegate = delegate;
+    public VertxGrpcLogsExporter(GrpcSender sender) {
+        this.sender = sender;
     }
 
     @Override
     public CompletableResultCode export(Collection<LogRecordData> logs) {
-        return delegate.export(LogsRequestMarshaler.create(logs), logs.size());
+        LogsRequestMarshaler marshaler = LogsRequestMarshaler.create(logs);
+        CompletableResultCode result = new CompletableResultCode();
+        sender.send(marshaler.toBinaryMessageWriter(),
+                response -> {
+                    if (response.getStatusCode() == GrpcStatusCode.OK) {
+                        result.succeed();
+                    } else {
+                        result.fail();
+                    }
+                },
+                throwable -> result.fail());
+        return result;
     }
 
     @Override
@@ -27,6 +39,6 @@ public class VertxGrpcLogsExporter implements LogRecordExporter {
 
     @Override
     public CompletableResultCode shutdown() {
-        return delegate.shutdown();
+        return sender.shutdown();
     }
 }

--- a/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/logs/VertxHttpLogsExporter.java
+++ b/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/logs/VertxHttpLogsExporter.java
@@ -2,22 +2,33 @@ package io.smallrye.opentelemetry.implementation.exporters.logs;
 
 import java.util.Collection;
 
-import io.opentelemetry.exporter.internal.http.HttpExporter;
 import io.opentelemetry.exporter.internal.otlp.logs.LogsRequestMarshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.export.HttpSender;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 
 public class VertxHttpLogsExporter implements LogRecordExporter {
-    private final HttpExporter<LogsRequestMarshaler> delegate;
+    private final HttpSender sender;
 
-    public VertxHttpLogsExporter(HttpExporter<LogsRequestMarshaler> delegate) {
-        this.delegate = delegate;
+    public VertxHttpLogsExporter(HttpSender sender) {
+        this.sender = sender;
     }
 
     @Override
     public CompletableResultCode export(Collection<LogRecordData> logs) {
-        return delegate.export(LogsRequestMarshaler.create(logs), logs.size());
+        LogsRequestMarshaler marshaler = LogsRequestMarshaler.create(logs);
+        CompletableResultCode result = new CompletableResultCode();
+        sender.send(marshaler.toBinaryMessageWriter(),
+                response -> {
+                    if (response.getStatusCode() >= 200 && response.getStatusCode() < 300) {
+                        result.succeed();
+                    } else {
+                        result.fail();
+                    }
+                },
+                throwable -> result.fail());
+        return result;
     }
 
     @Override
@@ -27,7 +38,6 @@ public class VertxHttpLogsExporter implements LogRecordExporter {
 
     @Override
     public CompletableResultCode shutdown() {
-        return delegate.shutdown();
+        return sender.shutdown();
     }
-
 }

--- a/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/logs/VertxLogsExporterProvider.java
+++ b/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/logs/VertxLogsExporterProvider.java
@@ -6,15 +6,14 @@ import static io.smallrye.opentelemetry.implementation.exporters.OtlpExporterUti
 
 import java.net.URISyntaxException;
 
-import io.opentelemetry.exporter.internal.otlp.logs.LogsRequestMarshaler;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.logs.ConfigurableLogRecordExporterProvider;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.smallrye.opentelemetry.implementation.exporters.AbstractVertxExporterProvider;
-import io.smallrye.opentelemetry.implementation.exporters.sender.VertxGrpcSender;
-import io.smallrye.opentelemetry.implementation.exporters.sender.VertxHttpSender;
+import io.smallrye.opentelemetry.senders.VertxGrpcSender;
+import io.smallrye.opentelemetry.senders.VertxHttpSender;
 
-public class VertxLogsExporterProvider extends AbstractVertxExporterProvider<LogsRequestMarshaler>
+public class VertxLogsExporterProvider extends AbstractVertxExporterProvider
         implements ConfigurableLogRecordExporterProvider {
     public VertxLogsExporterProvider() {
         super("log", "otlp");
@@ -26,9 +25,9 @@ public class VertxLogsExporterProvider extends AbstractVertxExporterProvider<Log
             final String protocol = getProtocol(config, getSignalType());
 
             if (PROTOCOL_GRPC.equals(protocol)) {
-                return new VertxGrpcLogsExporter(createGrpcExporter(config, VertxGrpcSender.GRPC_LOG_SERVICE_NAME));
+                return new VertxGrpcLogsExporter(createGrpcSender(config, VertxGrpcSender.GRPC_LOG_SERVICE_NAME));
             } else if (PROTOCOL_HTTP_PROTOBUF.equals(protocol)) {
-                return new VertxHttpLogsExporter(createHttpExporter(config, VertxHttpSender.LOGS_PATH));
+                return new VertxHttpLogsExporter(createHttpSender(config, VertxHttpSender.LOGS_PATH));
             } else {
                 throw buildUnsupportedProtocolException(protocol);
             }

--- a/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/metrics/VertxGrpcMetricExporter.java
+++ b/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/metrics/VertxGrpcMetricExporter.java
@@ -2,9 +2,10 @@ package io.smallrye.opentelemetry.implementation.exporters.metrics;
 
 import java.util.Collection;
 
-import io.opentelemetry.exporter.internal.grpc.GrpcExporter;
 import io.opentelemetry.exporter.internal.otlp.metrics.MetricsRequestMarshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.export.GrpcSender;
+import io.opentelemetry.sdk.common.export.GrpcStatusCode;
 import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentType;
@@ -16,21 +17,32 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 
 public class VertxGrpcMetricExporter implements MetricExporter {
 
-    private final GrpcExporter<MetricsRequestMarshaler> delegate;
+    private final GrpcSender sender;
     private final AggregationTemporalitySelector aggregationTemporalitySelector;
     private final DefaultAggregationSelector defaultAggregationSelector;
 
-    public VertxGrpcMetricExporter(GrpcExporter<MetricsRequestMarshaler> grpcExporter,
+    public VertxGrpcMetricExporter(GrpcSender sender,
             AggregationTemporalitySelector aggregationTemporalitySelector,
             DefaultAggregationSelector defaultAggregationSelector) {
-        this.delegate = grpcExporter;
+        this.sender = sender;
         this.aggregationTemporalitySelector = aggregationTemporalitySelector;
         this.defaultAggregationSelector = defaultAggregationSelector;
     }
 
     @Override
     public CompletableResultCode export(Collection<MetricData> metrics) {
-        return delegate.export(MetricsRequestMarshaler.create(metrics), metrics.size());
+        MetricsRequestMarshaler marshaler = MetricsRequestMarshaler.create(metrics);
+        CompletableResultCode result = new CompletableResultCode();
+        sender.send(marshaler.toBinaryMessageWriter(),
+                response -> {
+                    if (response.getStatusCode() == GrpcStatusCode.OK) {
+                        result.succeed();
+                    } else {
+                        result.fail();
+                    }
+                },
+                throwable -> result.fail());
+        return result;
     }
 
     @Override
@@ -40,7 +52,7 @@ public class VertxGrpcMetricExporter implements MetricExporter {
 
     @Override
     public CompletableResultCode shutdown() {
-        return delegate.shutdown();
+        return sender.shutdown();
     }
 
     @Override
@@ -55,6 +67,6 @@ public class VertxGrpcMetricExporter implements MetricExporter {
 
     @Override
     public MemoryMode getMemoryMode() {
-        return MemoryMode.IMMUTABLE_DATA; // Same as the default in the OTLP exporter
+        return MemoryMode.IMMUTABLE_DATA;
     }
 }

--- a/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/metrics/VertxHttpMetricsExporter.java
+++ b/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/metrics/VertxHttpMetricsExporter.java
@@ -2,9 +2,9 @@ package io.smallrye.opentelemetry.implementation.exporters.metrics;
 
 import java.util.Collection;
 
-import io.opentelemetry.exporter.internal.http.HttpExporter;
 import io.opentelemetry.exporter.internal.otlp.metrics.MetricsRequestMarshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.export.HttpSender;
 import io.opentelemetry.sdk.common.export.MemoryMode;
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentType;
@@ -16,21 +16,32 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 
 public class VertxHttpMetricsExporter implements MetricExporter {
 
-    private final HttpExporter<MetricsRequestMarshaler> delegate;
+    private final HttpSender sender;
     private final AggregationTemporalitySelector aggregationTemporalitySelector;
     private final DefaultAggregationSelector defaultAggregationSelector;
 
-    public VertxHttpMetricsExporter(HttpExporter<MetricsRequestMarshaler> delegate,
+    public VertxHttpMetricsExporter(HttpSender sender,
             AggregationTemporalitySelector aggregationTemporalitySelector,
             DefaultAggregationSelector defaultAggregationSelector) {
-        this.delegate = delegate;
+        this.sender = sender;
         this.aggregationTemporalitySelector = aggregationTemporalitySelector;
         this.defaultAggregationSelector = defaultAggregationSelector;
     }
 
     @Override
     public CompletableResultCode export(Collection<MetricData> metrics) {
-        return delegate.export(MetricsRequestMarshaler.create(metrics), metrics.size());
+        MetricsRequestMarshaler marshaler = MetricsRequestMarshaler.create(metrics);
+        CompletableResultCode result = new CompletableResultCode();
+        sender.send(marshaler.toBinaryMessageWriter(),
+                response -> {
+                    if (response.getStatusCode() >= 200 && response.getStatusCode() < 300) {
+                        result.succeed();
+                    } else {
+                        result.fail();
+                    }
+                },
+                throwable -> result.fail());
+        return result;
     }
 
     @Override
@@ -40,7 +51,7 @@ public class VertxHttpMetricsExporter implements MetricExporter {
 
     @Override
     public CompletableResultCode shutdown() {
-        return delegate.shutdown();
+        return sender.shutdown();
     }
 
     @Override
@@ -55,6 +66,6 @@ public class VertxHttpMetricsExporter implements MetricExporter {
 
     @Override
     public MemoryMode getMemoryMode() {
-        return MemoryMode.IMMUTABLE_DATA; // Same as the default in the OTLP exporter
+        return MemoryMode.IMMUTABLE_DATA;
     }
 }

--- a/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/metrics/VertxMetricsExporterProvider.java
+++ b/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/metrics/VertxMetricsExporterProvider.java
@@ -7,7 +7,6 @@ import static io.smallrye.opentelemetry.implementation.exporters.OtlpExporterUti
 
 import java.net.URISyntaxException;
 
-import io.opentelemetry.exporter.internal.otlp.metrics.MetricsRequestMarshaler;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigurationException;
 import io.opentelemetry.sdk.autoconfigure.spi.metrics.ConfigurableMetricExporterProvider;
@@ -18,10 +17,10 @@ import io.opentelemetry.sdk.metrics.export.DefaultAggregationSelector;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.metrics.internal.aggregator.AggregationUtil;
 import io.smallrye.opentelemetry.implementation.exporters.AbstractVertxExporterProvider;
-import io.smallrye.opentelemetry.implementation.exporters.sender.VertxGrpcSender;
-import io.smallrye.opentelemetry.implementation.exporters.sender.VertxHttpSender;
+import io.smallrye.opentelemetry.senders.VertxGrpcSender;
+import io.smallrye.opentelemetry.senders.VertxHttpSender;
 
-public class VertxMetricsExporterProvider extends AbstractVertxExporterProvider<MetricsRequestMarshaler>
+public class VertxMetricsExporterProvider extends AbstractVertxExporterProvider
         implements ConfigurableMetricExporterProvider {
 
     public VertxMetricsExporterProvider() {
@@ -35,12 +34,12 @@ public class VertxMetricsExporterProvider extends AbstractVertxExporterProvider<
 
             if (PROTOCOL_GRPC.equals(protocol)) {
                 return new VertxGrpcMetricExporter(
-                        createGrpcExporter(config, VertxGrpcSender.GRPC_METRIC_SERVICE_NAME),
+                        createGrpcSender(config, VertxGrpcSender.GRPC_METRIC_SERVICE_NAME),
                         aggregationTemporalityResolver(config),
                         aggregationResolver(config));
             } else if (PROTOCOL_HTTP_PROTOBUF.equals(protocol)) {
                 return new VertxHttpMetricsExporter(
-                        createHttpExporter(config, VertxHttpSender.METRICS_PATH),
+                        createHttpSender(config, VertxHttpSender.METRICS_PATH),
                         aggregationTemporalityResolver(config),
                         aggregationResolver(config));
             } else {

--- a/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/traces/VertxGrpcSpanExporter.java
+++ b/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/traces/VertxGrpcSpanExporter.java
@@ -2,24 +2,35 @@ package io.smallrye.opentelemetry.implementation.exporters.traces;
 
 import java.util.Collection;
 
-import io.opentelemetry.exporter.internal.grpc.GrpcExporter;
 import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.export.GrpcSender;
+import io.opentelemetry.sdk.common.export.GrpcStatusCode;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 
 public final class VertxGrpcSpanExporter implements SpanExporter {
 
-    private final GrpcExporter<TraceRequestMarshaler> delegate;
+    private final GrpcSender sender;
 
-    public VertxGrpcSpanExporter(GrpcExporter<TraceRequestMarshaler> delegate) {
-        this.delegate = delegate;
+    public VertxGrpcSpanExporter(GrpcSender sender) {
+        this.sender = sender;
     }
 
     @Override
     public CompletableResultCode export(Collection<SpanData> spans) {
-        TraceRequestMarshaler exportRequest = TraceRequestMarshaler.create(spans);
-        return delegate.export(exportRequest, spans.size());
+        TraceRequestMarshaler marshaler = TraceRequestMarshaler.create(spans);
+        CompletableResultCode result = new CompletableResultCode();
+        sender.send(marshaler.toBinaryMessageWriter(),
+                response -> {
+                    if (response.getStatusCode() == GrpcStatusCode.OK) {
+                        result.succeed();
+                    } else {
+                        result.fail();
+                    }
+                },
+                throwable -> result.fail());
+        return result;
     }
 
     @Override
@@ -29,6 +40,6 @@ public final class VertxGrpcSpanExporter implements SpanExporter {
 
     @Override
     public CompletableResultCode shutdown() {
-        return delegate.shutdown();
+        return sender.shutdown();
     }
 }

--- a/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/traces/VertxHttpSpanExporter.java
+++ b/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/traces/VertxHttpSpanExporter.java
@@ -2,24 +2,34 @@ package io.smallrye.opentelemetry.implementation.exporters.traces;
 
 import java.util.Collection;
 
-import io.opentelemetry.exporter.internal.http.HttpExporter;
 import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.export.HttpSender;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 
 public final class VertxHttpSpanExporter implements SpanExporter {
 
-    private final HttpExporter<TraceRequestMarshaler> delegate;
+    private final HttpSender sender;
 
-    public VertxHttpSpanExporter(HttpExporter<TraceRequestMarshaler> delegate) {
-        this.delegate = delegate;
+    public VertxHttpSpanExporter(HttpSender sender) {
+        this.sender = sender;
     }
 
     @Override
     public CompletableResultCode export(Collection<SpanData> spans) {
-        TraceRequestMarshaler exportRequest = TraceRequestMarshaler.create(spans);
-        return delegate.export(exportRequest, spans.size());
+        TraceRequestMarshaler marshaler = TraceRequestMarshaler.create(spans);
+        CompletableResultCode result = new CompletableResultCode();
+        sender.send(marshaler.toBinaryMessageWriter(),
+                response -> {
+                    if (response.getStatusCode() >= 200 && response.getStatusCode() < 300) {
+                        result.succeed();
+                    } else {
+                        result.fail();
+                    }
+                },
+                throwable -> result.fail());
+        return result;
     }
 
     @Override
@@ -29,6 +39,6 @@ public final class VertxHttpSpanExporter implements SpanExporter {
 
     @Override
     public CompletableResultCode shutdown() {
-        return delegate.shutdown();
+        return sender.shutdown();
     }
 }

--- a/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/traces/VertxSpanExporterProvider.java
+++ b/implementation/exporters/src/main/java/io/smallrye/opentelemetry/implementation/exporters/traces/VertxSpanExporterProvider.java
@@ -6,15 +6,14 @@ import static io.smallrye.opentelemetry.implementation.exporters.OtlpExporterUti
 
 import java.net.URISyntaxException;
 
-import io.opentelemetry.exporter.internal.otlp.traces.TraceRequestMarshaler;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.smallrye.opentelemetry.implementation.exporters.AbstractVertxExporterProvider;
-import io.smallrye.opentelemetry.implementation.exporters.sender.VertxGrpcSender;
-import io.smallrye.opentelemetry.implementation.exporters.sender.VertxHttpSender;
+import io.smallrye.opentelemetry.senders.VertxGrpcSender;
+import io.smallrye.opentelemetry.senders.VertxHttpSender;
 
-public class VertxSpanExporterProvider extends AbstractVertxExporterProvider<TraceRequestMarshaler>
+public class VertxSpanExporterProvider extends AbstractVertxExporterProvider
         implements ConfigurableSpanExporterProvider {
 
     public VertxSpanExporterProvider() {
@@ -27,9 +26,9 @@ public class VertxSpanExporterProvider extends AbstractVertxExporterProvider<Tra
             final String protocol = getProtocol(config, getSignalType());
 
             if (PROTOCOL_GRPC.equals(protocol)) {
-                return new VertxGrpcSpanExporter(createGrpcExporter(config, VertxGrpcSender.GRPC_TRACE_SERVICE_NAME));
+                return new VertxGrpcSpanExporter(createGrpcSender(config, VertxGrpcSender.GRPC_TRACE_SERVICE_NAME));
             } else if (PROTOCOL_HTTP_PROTOBUF.equals(protocol)) {
-                return new VertxHttpSpanExporter(createHttpExporter(config, VertxHttpSender.TRACES_PATH));
+                return new VertxHttpSpanExporter(createHttpSender(config, VertxHttpSender.TRACES_PATH));
             } else {
                 throw buildUnsupportedProtocolException(protocol);
             }

--- a/implementation/senders/pom.xml
+++ b/implementation/senders/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.smallrye.opentelemetry</groupId>
+        <artifactId>smallrye-opentelemetry-parent</artifactId>
+        <version>2.12.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>smallrye-opentelemetry-senders</artifactId>
+    <name>SmallRye OpenTelemetry: Senders</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-grpc-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>mutiny</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-annotation</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/implementation/senders/pom.xml
+++ b/implementation/senders/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.smallrye.opentelemetry</groupId>
         <artifactId>smallrye-opentelemetry-parent</artifactId>
-        <version>2.12.0-SNAPSHOT</version>
+        <version>2.13.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/implementation/senders/src/main/java/io/smallrye/opentelemetry/senders/VertxGrpcSender.java
+++ b/implementation/senders/src/main/java/io/smallrye/opentelemetry/senders/VertxGrpcSender.java
@@ -1,4 +1,6 @@
-package io.smallrye.opentelemetry.implementation.exporters.sender;
+package io.smallrye.opentelemetry.senders;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import java.io.IOException;
 import java.net.URI;
@@ -15,15 +17,19 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import io.netty.handler.codec.http.QueryStringDecoder;
-import io.opentelemetry.exporter.internal.grpc.GrpcResponse;
-import io.opentelemetry.exporter.internal.grpc.GrpcSender;
-import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.internal.ThrottlingLogger;
+import io.opentelemetry.sdk.common.export.GrpcResponse;
+import io.opentelemetry.sdk.common.export.GrpcSender;
+import io.opentelemetry.sdk.common.export.GrpcStatusCode;
+import io.opentelemetry.sdk.common.export.MessageWriter;
+import io.opentelemetry.sdk.common.internal.ThrottlingLogger;
+import io.smallrye.common.annotation.SuppressForbidden;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.opentelemetry.implementation.exporters.BufferOutputStream;
-import io.smallrye.opentelemetry.implementation.exporters.OtlpExporterUtil;
+import io.smallrye.opentelemetry.senders.common.BufferOutputStream;
+import io.smallrye.opentelemetry.senders.common.OTelExporterUtil;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientOptions;
@@ -36,7 +42,7 @@ import io.vertx.grpc.common.GrpcError;
 import io.vertx.grpc.common.GrpcStatus;
 import io.vertx.grpc.common.ServiceName;
 
-public final class VertxGrpcSender<T extends Marshaler> implements GrpcSender<T> {
+public final class VertxGrpcSender implements GrpcSender {
 
     public static final String GRPC_TRACE_SERVICE_NAME = "opentelemetry.proto.collector.trace.v1.TraceService";
     public static final String GRPC_METRIC_SERVICE_NAME = "opentelemetry.proto.collector.metrics.v1.MetricsService";
@@ -49,22 +55,20 @@ public final class VertxGrpcSender<T extends Marshaler> implements GrpcSender<T>
     private static final Logger internalLogger = Logger.getLogger(VertxGrpcSender.class.getName());
     private static final int MAX_ATTEMPTS = 3;
 
-    private final ThrottlingLogger logger = new ThrottlingLogger(internalLogger); // TODO: is there something in JBoss Logging we can use?
+    private final ThrottlingLogger logger = new ThrottlingLogger(internalLogger);
 
-    // We only log unimplemented once since it's a configuration issue that won't be recovered.
     private final AtomicBoolean loggedUnimplemented = new AtomicBoolean();
     private final AtomicBoolean isShutdown = new AtomicBoolean();
     private final CompletableResultCode shutdownResult = new CompletableResultCode();
     private final SocketAddress server;
     private final boolean compressionEnabled;
     private final Map<String, String> headers;
-    private final String signalType;
     private final String grpcEndpointPath;
+    private final Duration exportTimeout;
 
     private final GrpcClient client;
 
     public VertxGrpcSender(
-            String signalType,
             URI grpcBaseUri,
             String grpcEndpointPath,
             boolean compressionEnabled,
@@ -72,31 +76,35 @@ public final class VertxGrpcSender<T extends Marshaler> implements GrpcSender<T>
             Map<String, String> headersMap,
             Consumer<HttpClientOptions> clientOptionsCustomizer,
             Vertx vertx) {
-        this.signalType = signalType;
         this.grpcEndpointPath = grpcEndpointPath;
-        this.server = SocketAddress.inetSocketAddress(OtlpExporterUtil.getPort(grpcBaseUri), grpcBaseUri.getHost());
+        this.server = SocketAddress.inetSocketAddress(OTelExporterUtil.getPort(grpcBaseUri), grpcBaseUri.getHost());
         this.compressionEnabled = compressionEnabled;
         this.headers = headersMap;
+        this.exportTimeout = timeout;
         var httpClientOptions = new HttpClientOptions()
                 .setHttp2ClearTextUpgrade(false) // needed otherwise connections get closed immediately
                 .setReadIdleTimeout((int) timeout.getSeconds())
                 .setTracingPolicy(TracingPolicy.IGNORE); // needed to avoid tracing the calls from this gRPC client
         clientOptionsCustomizer.accept(httpClientOptions);
+        // FIXME No way to set the connection exception handler for the gRPC client, at the moment.
         this.client = GrpcClient.client(vertx, httpClientOptions);
     }
 
     @Override
-    public void send(T marshaler, Consumer<GrpcResponse> onSuccess, Consumer<Throwable> onError) {
+    public void send(MessageWriter messageWriter,
+            Consumer<GrpcResponse> onResponse,
+            Consumer<Throwable> onError) {
         if (isShutdown.get()) {
             return;
         }
 
-        final String marshalerType = marshaler.getClass().getSimpleName();
-        var onSuccessHandler = new ClientRequestOnSuccessHandler(client, server, headers, compressionEnabled, marshaler,
-                loggedUnimplemented, logger, marshalerType, onSuccess, onError, 1, grpcEndpointPath,
-                isShutdown::get);
+        final String marshalerType = messageWriter.getClass().getSimpleName();
+        var onSuccessHandler = new ClientRequestOnSuccessHandler(client, server, headers, compressionEnabled,
+                messageWriter,
+                loggedUnimplemented, logger, marshalerType, onResponse, onError, 1, grpcEndpointPath,
+                isShutdown::get, exportTimeout);
 
-        initiateSend(marshaler, client, server, MAX_ATTEMPTS, onSuccessHandler, new Consumer<>() {
+        initiateSend(client, server, MAX_ATTEMPTS, onSuccessHandler, exportTimeout, new Consumer<>() {
             @Override
             public void accept(Throwable throwable) {
                 failOnClientRequest(marshalerType, throwable, onError);
@@ -105,39 +113,47 @@ public final class VertxGrpcSender<T extends Marshaler> implements GrpcSender<T>
     }
 
     @Override
+    @SuppressForbidden(reason = "The use of ThrottlingLogger mandates the use of java.util.logging")
     public CompletableResultCode shutdown() {
         if (!isShutdown.compareAndSet(false, true)) {
             logger.log(Level.FINE, "Calling shutdown() multiple times.");
             return shutdownResult;
         }
 
-        client.close()
-                .onSuccess(
-                        new Handler<>() {
-                            @Override
-                            public void handle(Void event) {
-                                shutdownResult.succeed();
-                            }
-                        })
-                .onFailure(new Handler<>() {
-                    @Override
-                    public void handle(Throwable event) {
-                        shutdownResult.fail();
-                    }
-                });
+        try {
+            client.close()
+                    .onSuccess(
+                            new Handler<>() {
+                                @Override
+                                public void handle(Void event) {
+                                    shutdownResult.succeed();
+                                }
+                            })
+                    .onFailure(new Handler<>() {
+                        @Override
+                        public void handle(Throwable event) {
+                            shutdownResult.fail();
+                        }
+                    });
+        } catch (RejectedExecutionException e) {
+            internalLogger.log(Level.FINE, "Unable to complete shutdown", e);
+            // if Netty's ThreadPool has been closed, this onSuccess() will immediately throw RejectedExecutionException
+            // which we need to handle
+            shutdownResult.fail();
+        }
         return shutdownResult;
     }
 
-    void initiateSend(Marshaler request,
-            GrpcClient client,
-            SocketAddress server,
+    private static void initiateSend(GrpcClient client, SocketAddress server,
             int numberOfAttempts,
-            Handler<GrpcClientRequest<Buffer, Buffer>> onSuccessHandler,
+            Handler<GrpcClientRequest<Buffer, Buffer>> onSuccessHandler, Duration exportTimeout,
             Consumer<Throwable> onFailureCallback) {
         Uni.createFrom().completionStage(new Supplier<CompletionStage<GrpcClientRequest<Buffer, Buffer>>>() {
             @Override
-            public CompletionStage get() {
-                return client.request(server).toCompletionStage();
+            public CompletionStage<GrpcClientRequest<Buffer, Buffer>> get() {
+                return client.request(server)
+                        .timeout(exportTimeout.toMillis(), MILLISECONDS)
+                        .toCompletionStage();
             }
         })
                 .onFailure(new Predicate<Throwable>() {
@@ -158,62 +174,72 @@ public final class VertxGrpcSender<T extends Marshaler> implements GrpcSender<T>
                 .retry()
                 .withBackOff(Duration.ofMillis(100))
                 .atMost(numberOfAttempts)
-                .subscribe().with(request1 -> onSuccessHandler.handle(request1), onFailureCallback);
+                .subscribe().with(
+                        new Consumer<>() {
+                            @Override
+                            public void accept(GrpcClientRequest<Buffer, Buffer> request) {
+                                onSuccessHandler.handle(request);
+                            }
+                        }, onFailureCallback);
     }
 
+    @SuppressForbidden(reason = "The use of ThrottlingLogger mandates the use of java.util.logging")
     private void failOnClientRequest(String type, Throwable t, Consumer<Throwable> onError) {
         String message = "Failed to export "
                 + type
-                + "s. The request could not be executed. Full error message: "
+                + ". The request could not be executed. Full error message: "
                 + (t.getMessage() == null ? t.getClass().getName() : t.getMessage());
         logger.log(Level.WARNING, message);
         onError.accept(t);
     }
 
-    private final class ClientRequestOnSuccessHandler implements Handler<GrpcClientRequest<Buffer, Buffer>> {
+    private static final class ClientRequestOnSuccessHandler implements Handler<GrpcClientRequest<Buffer, Buffer>> {
 
         private final GrpcClient client;
         private final SocketAddress server;
         private final Map<String, String> headers;
         private final boolean compressionEnabled;
 
-        private final Marshaler marshaler;
+        private final MessageWriter messageWriter;
         private final AtomicBoolean loggedUnimplemented;
         private final ThrottlingLogger logger;
         private final String type;
-        private final Consumer<GrpcResponse> onSuccess;
+        private final Consumer<GrpcResponse> onResponse;
         private final Consumer<Throwable> onError;
         private final String grpcEndpointPath;
 
         private final int attemptNumber;
         private final Supplier<Boolean> isShutdown;
+        private final Duration exportTimeout;
 
         public ClientRequestOnSuccessHandler(GrpcClient client,
                 SocketAddress server,
                 Map<String, String> headers,
                 boolean compressionEnabled,
-                Marshaler marshaler,
+                MessageWriter messageWriter,
                 AtomicBoolean loggedUnimplemented,
                 ThrottlingLogger logger,
                 String type,
-                Consumer<GrpcResponse> onSuccess,
+                Consumer<GrpcResponse> onResponse,
                 Consumer<Throwable> onError,
                 int attemptNumber,
                 String grpcEndpointPath,
-                Supplier<Boolean> isShutdown) {
+                Supplier<Boolean> isShutdown,
+                Duration exportTimeout) {
             this.client = client;
             this.server = server;
             this.grpcEndpointPath = grpcEndpointPath;
             this.headers = headers;
             this.compressionEnabled = compressionEnabled;
-            this.marshaler = marshaler;
+            this.messageWriter = messageWriter;
             this.loggedUnimplemented = loggedUnimplemented;
             this.logger = logger;
             this.type = type;
-            this.onSuccess = onSuccess;
+            this.onResponse = onResponse;
             this.onError = onError;
             this.attemptNumber = attemptNumber;
             this.isShutdown = isShutdown;
+            this.exportTimeout = exportTimeout;
         }
 
         @Override
@@ -234,10 +260,10 @@ public final class VertxGrpcSender<T extends Marshaler> implements GrpcSender<T>
             }
 
             try {
-                int messageSize = marshaler.getBinarySerializedSize();
+                int messageSize = messageWriter.getContentLength();
                 Buffer buffer = Buffer.buffer(messageSize);
                 var os = new BufferOutputStream(buffer);
-                marshaler.writeBinaryTo(os);
+                messageWriter.writeMessage(os);
                 request.send(buffer).onSuccess(new Handler<>() {
                     @Override
                     public void handle(GrpcClientResponse<Buffer, Buffer> response) {
@@ -246,9 +272,9 @@ public final class VertxGrpcSender<T extends Marshaler> implements GrpcSender<T>
                             public void handle(Throwable t) {
                                 if (attemptNumber <= MAX_ATTEMPTS && !isShutdown.get()) {
                                     // retry
-                                    initiateSend(marshaler, client, server,
+                                    initiateSend(client, server,
                                             MAX_ATTEMPTS - attemptNumber,
-                                            newAttempt(),
+                                            newAttempt(), exportTimeout,
                                             new Consumer<>() {
                                                 @Override
                                                 public void accept(Throwable throwable) {
@@ -270,7 +296,43 @@ public final class VertxGrpcSender<T extends Marshaler> implements GrpcSender<T>
                             public void handle(Void ignored) {
                                 GrpcStatus status = getStatus(response);
                                 if (status == GrpcStatus.OK) {
-                                    onSuccess.accept(GrpcResponse.create(response.status().code, response.statusMessage()));
+                                    onResponse.accept(new GrpcResponse() {
+                                        @Override
+                                        public GrpcStatusCode getStatusCode() {
+                                            return GrpcStatusCode.fromValue(status.code);
+                                        }
+
+                                        @Override
+                                        public String getStatusDescription() {
+                                            return status.name();
+                                        }
+
+                                        @Override
+                                        public byte[] getResponseMessage() {
+                                            if (response == null) {
+                                                return null;
+                                            }
+                                            Promise<String> promise = Promise.promise();
+                                            StringBuilder sb = new StringBuilder();
+                                            response.handler(msg -> {
+                                                sb.append(msg.toString());
+                                            });
+                                            response.endHandler(v -> {
+                                                // Done reading stream
+                                                promise.complete(sb.toString());
+                                            });
+                                            response.exceptionHandler(promise::fail);
+                                            String result = promise.future()
+                                                    .timeout(exportTimeout.toMillis(), MILLISECONDS)
+                                                    .recover(throwable -> Future.succeededFuture(
+                                                            "Response error: " + throwable.getMessage()))
+                                                    .result();
+                                            if (result == null || result.isEmpty()) {
+                                                return null;
+                                            }
+                                            return result.getBytes(StandardCharsets.UTF_8);
+                                        }
+                                    });
                                 } else {
                                     handleError(status, response);
                                 }
@@ -306,7 +368,7 @@ public final class VertxGrpcSender<T extends Marshaler> implements GrpcSender<T>
                                             Level.WARNING,
                                             "Failed to export "
                                                     + type
-                                                    + "s. Perhaps the collector does not support collecting traces using grpc? Try configuring 'quarkus.otel.exporter.otlp.traces.protocol=http/protobuf'");
+                                                    + "s. Perhaps the collector does not support collecting traces using grpc? Try configuring the protocol to 'http/protobuf'");
                                 } else {
                                     logger.log(
                                             Level.WARNING,
@@ -328,6 +390,7 @@ public final class VertxGrpcSender<T extends Marshaler> implements GrpcSender<T>
                         }
                     }
 
+                    @SuppressForbidden(reason = "The use of ThrottlingLogger mandates the use of java.util.logging")
                     private void logUnimplemented(Logger logger, String type, String fullErrorMessage) {
                         String envVar;
                         switch (type) {
@@ -390,8 +453,9 @@ public final class VertxGrpcSender<T extends Marshaler> implements GrpcSender<T>
                     public void handle(Throwable t) {
                         if (attemptNumber <= MAX_ATTEMPTS && !isShutdown.get()) {
                             // retry
-                            initiateSend(marshaler, client, server, MAX_ATTEMPTS - attemptNumber,
-                                    newAttempt(),
+                            initiateSend(client, server,
+                                    MAX_ATTEMPTS - attemptNumber,
+                                    newAttempt(), exportTimeout,
                                     new Consumer<>() {
                                         @Override
                                         public void accept(Throwable throwable) {
@@ -424,9 +488,9 @@ public final class VertxGrpcSender<T extends Marshaler> implements GrpcSender<T>
         }
 
         public ClientRequestOnSuccessHandler newAttempt() {
-            return new ClientRequestOnSuccessHandler(client, server, headers, compressionEnabled, marshaler,
-                    loggedUnimplemented, logger, type, onSuccess, onError, attemptNumber + 1,
-                    grpcEndpointPath, isShutdown);
+            return new ClientRequestOnSuccessHandler(client, server, headers, compressionEnabled, messageWriter,
+                    loggedUnimplemented, logger, type, onResponse, onError, attemptNumber + 1,
+                    grpcEndpointPath, isShutdown, exportTimeout);
         }
     }
 }

--- a/implementation/senders/src/main/java/io/smallrye/opentelemetry/senders/VertxHttpSender.java
+++ b/implementation/senders/src/main/java/io/smallrye/opentelemetry/senders/VertxHttpSender.java
@@ -1,6 +1,6 @@
-package io.smallrye.opentelemetry.implementation.exporters.sender;
+package io.smallrye.opentelemetry.senders;
 
-import static io.smallrye.opentelemetry.implementation.exporters.OtlpExporterUtil.getPort;
+import static io.smallrye.opentelemetry.senders.common.OTelExporterUtil.getPort;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -17,12 +17,14 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.GZIPOutputStream;
 
-import io.opentelemetry.exporter.internal.http.HttpSender;
-import io.opentelemetry.exporter.internal.marshal.Marshaler;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.internal.ThrottlingLogger;
+import io.opentelemetry.sdk.common.export.HttpResponse;
+import io.opentelemetry.sdk.common.export.HttpSender;
+import io.opentelemetry.sdk.common.export.MessageWriter;
+import io.opentelemetry.sdk.common.internal.ThrottlingLogger;
+import io.smallrye.common.annotation.SuppressForbidden;
 import io.smallrye.mutiny.Uni;
-import io.smallrye.opentelemetry.implementation.exporters.BufferOutputStream;
+import io.smallrye.opentelemetry.senders.common.BufferOutputStream;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -41,7 +43,8 @@ public final class VertxHttpSender implements HttpSender {
     public static final String LOGS_PATH = "/v1/logs";
 
     private static final Logger internalLogger = Logger.getLogger(VertxHttpSender.class.getName());
-    private static final ThrottlingLogger logger = new ThrottlingLogger(internalLogger);
+
+    private static final ThrottlingLogger throttlingLogger = new ThrottlingLogger(internalLogger);
 
     private static final int MAX_ATTEMPTS = 3;
 
@@ -72,7 +75,14 @@ public final class VertxHttpSender implements HttpSender {
                 .setDefaultPort(getPort(baseUri))
                 .setTracingPolicy(TracingPolicy.IGNORE); // needed to avoid tracing the calls from this http client
         clientOptionsCustomizer.accept(httpClientOptions);
-        this.client = vertx.createHttpClient(httpClientOptions);
+        this.client = vertx.httpClientBuilder()
+                .with(httpClientOptions)
+                .withConnectHandler(connection -> {
+                    connection.exceptionHandler(thw -> {
+                        throttlingLogger.log(Level.WARNING, "Connection handler exception: ", thw);
+                    });
+                })
+                .build();
     }
 
     private final AtomicBoolean isShutdown = new AtomicBoolean();
@@ -93,27 +103,41 @@ public final class VertxHttpSender implements HttpSender {
     }
 
     @Override
-    public void send(Marshaler marshaler,
-            int contentLength,
-            Consumer<Response> onHttpResponseRead,
+    public void send(MessageWriter requestBodyWriter,
+            Consumer<HttpResponse> onHttpResponseRead,
             Consumer<Throwable> onError) {
         if (isShutdown.get()) {
             return;
         }
 
+        String writerType = requestBodyWriter.getClass().getSimpleName();
         String requestURI = basePath + signalPath;
         var clientRequestSuccessHandler = new ClientRequestSuccessHandler(client, requestURI, headers, compressionEnabled,
                 contentType,
-                contentLength, onHttpResponseRead,
-                onError, marshaler, 1, isShutdown::get);
-        initiateSend(client, requestURI, MAX_ATTEMPTS, clientRequestSuccessHandler, onError, isShutdown::get);
+                onHttpResponseRead,
+                onError, requestBodyWriter, 1, isShutdown::get);
+        initiateSend(client, requestURI, MAX_ATTEMPTS, clientRequestSuccessHandler, new Consumer<>() {
+            @Override
+            public void accept(Throwable throwable) {
+                failOnClientRequest(writerType, throwable, onError);
+            }
+        });
+    }
+
+    @SuppressForbidden(reason = "The use of ThrottlingLogger mandates the use of java.util.logging")
+    private void failOnClientRequest(String type, Throwable t, Consumer<Throwable> onError) {
+        String message = "Failed to export "
+                + type
+                + ". The request could not be executed. Full error message: "
+                + (t.getMessage() == null ? t.getClass().getName() : t.getMessage());
+        throttlingLogger.log(Level.WARNING, message);
+        onError.accept(t);
     }
 
     private static void initiateSend(HttpClient client, String requestURI,
             int numberOfAttempts,
             Handler<HttpClientRequest> clientRequestSuccessHandler,
-            Consumer<Throwable> onError,
-            Supplier<Boolean> isShutdown) {
+            Consumer<Throwable> onFailureCallback) {
         Uni.createFrom().completionStage(new Supplier<CompletionStage<HttpClientRequest>>() {
             @Override
             public CompletionStage<HttpClientRequest> get() {
@@ -144,30 +168,36 @@ public final class VertxHttpSender implements HttpSender {
                             public void accept(HttpClientRequest request) {
                                 clientRequestSuccessHandler.handle(request);
                             }
-                        }, onError);
+                        }, onFailureCallback);
     }
 
     @Override
+    @SuppressForbidden(reason = "The use of ThrottlingLogger mandates the use of java.util.logging")
     public CompletableResultCode shutdown() {
         if (!isShutdown.compareAndSet(false, true)) {
-            logger.log(Level.FINE, "Calling shutdown() multiple times.");
+            throttlingLogger.log(Level.FINE, "Calling shutdown() multiple times.");
             return shutdownResult;
         }
 
-        client.close()
-                .onSuccess(
-                        new Handler<>() {
-                            @Override
-                            public void handle(Void event) {
-                                shutdownResult.succeed();
-                            }
-                        })
-                .onFailure(new Handler<>() {
-                    @Override
-                    public void handle(Throwable event) {
-                        shutdownResult.fail();
-                    }
-                });
+        try {
+            client.close()
+                    .onSuccess(
+                            new Handler<>() {
+                                @Override
+                                public void handle(Void event) {
+                                    shutdownResult.succeed();
+                                }
+                            })
+                    .onFailure(new Handler<>() {
+                        @Override
+                        public void handle(Throwable event) {
+                            shutdownResult.fail();
+                        }
+                    });
+        } catch (RejectedExecutionException e) {
+            internalLogger.log(Level.FINE, "Unable to complete shutdown", e);
+            shutdownResult.fail();
+        }
         return shutdownResult;
     }
 
@@ -177,10 +207,9 @@ public final class VertxHttpSender implements HttpSender {
         private final Map<String, String> headers;
         private final boolean compressionEnabled;
         private final String contentType;
-        private final int contentLength;
-        private final Consumer<Response> onHttpResponseRead;
+        private final Consumer<HttpResponse> onHttpResponseRead;
         private final Consumer<Throwable> onError;
-        private final Marshaler marshaler;
+        private final MessageWriter requestBodyWriter;
 
         private final int attemptNumber;
         private final Supplier<Boolean> isShutdown;
@@ -189,10 +218,9 @@ public final class VertxHttpSender implements HttpSender {
                 String requestURI, Map<String, String> headers,
                 boolean compressionEnabled,
                 String contentType,
-                int contentLength,
-                Consumer<Response> onHttpResponseRead,
+                Consumer<HttpResponse> onHttpResponseRead,
                 Consumer<Throwable> onError,
-                Marshaler marshaler,
+                MessageWriter requestBodyWriter,
                 int attemptNumber,
                 Supplier<Boolean> isShutdown) {
             this.client = client;
@@ -200,10 +228,9 @@ public final class VertxHttpSender implements HttpSender {
             this.headers = headers;
             this.compressionEnabled = compressionEnabled;
             this.contentType = contentType;
-            this.contentLength = contentLength;
             this.onHttpResponseRead = onHttpResponseRead;
             this.onError = onError;
-            this.marshaler = marshaler;
+            this.requestBodyWriter = requestBodyWriter;
             this.attemptNumber = attemptNumber;
             this.isShutdown = isShutdown;
         }
@@ -216,7 +243,6 @@ public final class VertxHttpSender implements HttpSender {
                 public void handle(AsyncResult<HttpClientResponse> callResult) {
                     if (callResult.succeeded()) {
                         HttpClientResponse clientResponse = callResult.result();
-                        Throwable cause = callResult.cause();
                         clientResponse.body(new Handler<>() {
                             @Override
                             public void handle(AsyncResult<Buffer> bodyResult) {
@@ -227,24 +253,23 @@ public final class VertxHttpSender implements HttpSender {
                                             initiateSend(client, requestURI,
                                                     MAX_ATTEMPTS - attemptNumber,
                                                     newAttempt(),
-                                                    onError,
-                                                    isShutdown);
+                                                    onError);
                                             return;
                                         }
                                     }
-                                    onHttpResponseRead.accept(new Response() {
+                                    onHttpResponseRead.accept(new HttpResponse() {
                                         @Override
-                                        public int statusCode() {
+                                        public int getStatusCode() {
                                             return clientResponse.statusCode();
                                         }
 
                                         @Override
-                                        public String statusMessage() {
+                                        public String getStatusMessage() {
                                             return clientResponse.statusMessage();
                                         }
 
                                         @Override
-                                        public byte[] responseBody() {
+                                        public byte[] getResponseBody() {
                                             return bodyResult.result().getBytes();
                                         }
                                     });
@@ -254,8 +279,7 @@ public final class VertxHttpSender implements HttpSender {
                                         initiateSend(client, requestURI,
                                                 MAX_ATTEMPTS - attemptNumber,
                                                 newAttempt(),
-                                                onError,
-                                                isShutdown);
+                                                onError);
                                     } else {
                                         onError.accept(bodyResult.cause());
                                     }
@@ -268,8 +292,7 @@ public final class VertxHttpSender implements HttpSender {
                             initiateSend(client, requestURI,
                                     MAX_ATTEMPTS - attemptNumber,
                                     newAttempt(),
-                                    onError,
-                                    isShutdown);
+                                    onError);
                         } else {
                             onError.accept(callResult.cause());
                         }
@@ -278,18 +301,18 @@ public final class VertxHttpSender implements HttpSender {
             })
                     .putHeader("Content-Type", contentType);
 
-            Buffer buffer = Buffer.buffer(contentLength);
+            Buffer buffer = Buffer.buffer(requestBodyWriter.getContentLength());
             OutputStream os = new BufferOutputStream(buffer);
             if (compressionEnabled) {
                 clientRequest.putHeader("Content-Encoding", "gzip");
                 try (var gzos = new GZIPOutputStream(os)) {
-                    marshaler.writeBinaryTo(gzos);
+                    requestBodyWriter.writeMessage(gzos);
                 } catch (IOException e) {
                     throw new IllegalStateException(e);
                 }
             } else {
                 try {
-                    marshaler.writeBinaryTo(os);
+                    requestBodyWriter.writeMessage(os);
                 } catch (IOException e) {
                     throw new IllegalStateException(e);
                 }
@@ -306,8 +329,8 @@ public final class VertxHttpSender implements HttpSender {
 
         public ClientRequestSuccessHandler newAttempt() {
             return new ClientRequestSuccessHandler(client, requestURI, headers, compressionEnabled,
-                    contentType, contentLength, onHttpResponseRead,
-                    onError, marshaler, attemptNumber + 1, isShutdown);
+                    contentType, onHttpResponseRead,
+                    onError, requestBodyWriter, attemptNumber + 1, isShutdown);
         }
     }
 }

--- a/implementation/senders/src/main/java/io/smallrye/opentelemetry/senders/common/BufferOutputStream.java
+++ b/implementation/senders/src/main/java/io/smallrye/opentelemetry/senders/common/BufferOutputStream.java
@@ -1,4 +1,4 @@
-package io.smallrye.opentelemetry.implementation.exporters;
+package io.smallrye.opentelemetry.senders.common;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/implementation/senders/src/main/java/io/smallrye/opentelemetry/senders/common/OTelExporterUtil.java
+++ b/implementation/senders/src/main/java/io/smallrye/opentelemetry/senders/common/OTelExporterUtil.java
@@ -1,0 +1,26 @@
+package io.smallrye.opentelemetry.senders.common;
+
+import java.net.URI;
+import java.util.Locale;
+
+public final class OTelExporterUtil {
+
+    private OTelExporterUtil() {
+    }
+
+    public static int getPort(URI uri) {
+        int originalPort = uri.getPort();
+        if (originalPort > -1) {
+            return originalPort;
+        }
+
+        if (isHttps(uri)) {
+            return 443;
+        }
+        return 80;
+    }
+
+    public static boolean isHttps(URI uri) {
+        return "https".equals(uri.getScheme().toLowerCase(Locale.ROOT));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -15,15 +15,15 @@
     <url>https://smallrye.io</url>
 
     <properties>
-        <version.opentelemetry>1.49.0</version.opentelemetry>
-        <version.opentelemetry.instrumentation>2.15.0</version.opentelemetry.instrumentation>
+        <version.opentelemetry>1.60.1</version.opentelemetry>
+        <version.opentelemetry.instrumentation>2.26.1</version.opentelemetry.instrumentation>
         <version.opentelemetry.semconv>1.32.0</version.opentelemetry.semconv>
         <version.microprofile.opentelemetry>2.1</version.microprofile.opentelemetry>
         <version.microprofile.config>3.1</version.microprofile.config>
         <version.mutiny>3.0.0</version.mutiny>
         <version.smallrye.common>2.13.9</version.smallrye.common>
         <version.resteasy>6.2.12.Final</version.resteasy>
-        <version.vertx.grpc>4.5.15</version.vertx.grpc>
+        <version.vertx.grpc>4.5.26</version.vertx.grpc>
         <micrometer.version>1.15.4</micrometer.version>
 
         <!-- Test -->
@@ -139,6 +139,11 @@
             </dependency>
             <dependency>
                 <groupId>io.smallrye.opentelemetry</groupId>
+                <artifactId>smallrye-opentelemetry-senders</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.opentelemetry</groupId>
                 <artifactId>smallrye-opentelemetry-exporters</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -191,6 +196,7 @@
         <module>api</module>
         <module>implementation/propagation</module>
         <module>implementation/config</module>
+        <module>implementation/senders</module>
         <module>implementation/exporters</module>
         <module>implementation/cdi</module>
         <module>implementation/rest</module>


### PR DESCRIPTION
- Extract Vert.x OTLP senders from Quarkus into a new `smallrye-opentelemetry-senders` module with `VertxGrpcSender` and `VertxHttpSender` using public OTel SDK APIs (`GrpcSender/HttpSender`) instead of internal ones. The `VertxHttpSender` uses        
  `vertx.httpClientBuilder()` instead of internal `HttpClientBuilderImpl`.                                                                                                                                                                                                                                   
- Updated `smallrye-opentelemetry-exporters` to depend on the new `senders` module, removing duplicate sender classes and replacing internal `GrpcExporter/HttpExporter` wrappers with direct sender usage via `toBinaryMessageWriter()`.                                                                                                                                                                                                                       
- Upgraded:
   -  OTel SDK 1.49.0 → 1.62.0, 
   - Instrumentation 2.15.0 → 2.27.0, 
   - Vert.x 4.5.15 → 4.5.26. 
   - Fixed resulting API migrations in `smallrye-opentelemetry-cdi`: `SpanNames` package move, and individual runtime metrics classes replaced with `RuntimeMetrics.create()`.  