### PR TITLE
Override BSP when running under SM

### DIFF
--- a/examples/agent/pom.xml
+++ b/examples/agent/pom.xml
@@ -28,8 +28,8 @@
         <version.resteasy>6.2.16.Final</version.resteasy>
         <version.smallrye.config>3.13.4</version.smallrye.config>
 
-        <version.opentelemetry>1.49.0</version.opentelemetry>
-        <version.opentelemetry.agent>2.15.0</version.opentelemetry.agent>
+        <version.opentelemetry>1.62.0</version.opentelemetry>
+        <version.opentelemetry.agent>2.28.0</version.opentelemetry.agent>
     </properties>
 
     <build>

--- a/examples/library/pom.xml
+++ b/examples/library/pom.xml
@@ -28,8 +28,8 @@
         <version.resteasy>6.2.16.Final</version.resteasy>
         <version.smallrye.config>3.13.4</version.smallrye.config>
 
-        <version.opentelemetry.agent>2.15.0</version.opentelemetry.agent>
-        <version.opentelemetry.exporter>1.49.0</version.opentelemetry.exporter>
+        <version.opentelemetry.agent>2.28.0</version.opentelemetry.agent>
+        <version.opentelemetry.exporter>1.62.0</version.opentelemetry.exporter>
     </properties>
 
     <build>

--- a/implementation/cdi/src/main/java/io/smallrye/opentelemetry/implementation/cdi/OpenTelemetryProducer.java
+++ b/implementation/cdi/src/main/java/io/smallrye/opentelemetry/implementation/cdi/OpenTelemetryProducer.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -30,9 +31,10 @@ import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.instrumentation.runtimemetrics.java8.RuntimeMetrics;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
 import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.smallrye.opentelemetry.api.OpenTelemetryBuilderGetter;
 import io.smallrye.opentelemetry.api.OpenTelemetryConfig;
 import io.smallrye.opentelemetry.api.OpenTelemetryLogHandler;
@@ -48,41 +50,26 @@ public class OpenTelemetryProducer {
     @Produces
     @Singleton
     public OpenTelemetry getOpenTelemetry(final OpenTelemetryConfig config) {
-        AutoConfiguredOpenTelemetrySdkBuilder autoConfiguredOpenTelemetrySdkBuilder = new OpenTelemetryBuilderGetter()
-                .apply(config).disableShutdownHook();
+        final AtomicReference<SpanExporter> exporter = new AtomicReference<>();
 
-        AutoConfiguredOpenTelemetrySdk otelSdk;
-        if (System.getSecurityManager() == null) {
-            otelSdk = autoConfiguredOpenTelemetrySdkBuilder.build();
-        } else {
-            // Requires FilePermission/RuntimePermission
-            otelSdk = AccessController.doPrivileged(
-                    (PrivilegedAction<AutoConfiguredOpenTelemetrySdk>) autoConfiguredOpenTelemetrySdkBuilder::build);
-        }
+        AutoConfiguredOpenTelemetrySdkBuilder builder = new OpenTelemetryBuilderGetter()
+                .apply(config)
+                .disableShutdownHook()
+                // Capture exporter for use later
+                .addSpanExporterCustomizer((e, cp) -> {
+                    exporter.set(e);
+                    return e;
+                })
+                // Avoid BatchSpanProcessor under SM due to policy violation issues
+                .addSpanProcessorCustomizer(
+                        (sp, cp) -> (System.getSecurityManager() != null) ? SimpleSpanProcessor.create(exporter.get()) : sp);
 
-        OpenTelemetry openTelemetry = otelSdk.getOpenTelemetrySdk();
-
-        RuntimeMetrics runtimeMetrics;
-        if (System.getSecurityManager() == null) {
-            runtimeMetrics = RuntimeMetrics.create(openTelemetry);
-        } else {
-            // Requires FilePermission/RuntimePermission/ManagementPermission
-            runtimeMetrics = AccessController.doPrivileged(
-                    (PrivilegedAction<RuntimeMetrics>) () -> RuntimeMetrics.create(openTelemetry));
-        }
-        closeables.add(runtimeMetrics);
-
-        if (System.getSecurityManager() == null) {
-            OpenTelemetryLogHandler.install(openTelemetry);
-        } else {
-            // Requires LoggingPermission
-            AccessController.doPrivileged((PrivilegedAction<List<AutoCloseable>>) () -> {
-                OpenTelemetryLogHandler.install(openTelemetry);
-                return null;
-            });
-        }
-
-        return openTelemetry;
+        return performPrivileged(() -> {
+            var otel = builder.build().getOpenTelemetrySdk();
+            closeables.add(RuntimeMetrics.create(otel));
+            OpenTelemetryLogHandler.install(otel);
+            return otel;
+        });
     }
 
     @Produces
@@ -197,5 +184,13 @@ public class OpenTelemetryProducer {
         shutdown.add(openTelemetrySdk.getSdkMeterProvider().shutdown());
         shutdown.add(openTelemetrySdk.getSdkLoggerProvider().shutdown());
         CompletableResultCode.ofAll(shutdown).join(10, TimeUnit.SECONDS);
+    }
+
+    static <T> T performPrivileged(PrivilegedAction<T> action) {
+        if (System.getSecurityManager() == null) {
+            return action.run();
+        } else {
+            return AccessController.doPrivileged(action);
+        }
     }
 }

--- a/implementation/cdi/src/main/java/io/smallrye/opentelemetry/implementation/cdi/WithSpanInterceptor.java
+++ b/implementation/cdi/src/main/java/io/smallrye/opentelemetry/implementation/cdi/WithSpanInterceptor.java
@@ -2,6 +2,7 @@ package io.smallrye.opentelemetry.implementation.cdi;
 
 import static io.smallrye.opentelemetry.api.OpenTelemetryConfig.INSTRUMENTATION_NAME;
 import static io.smallrye.opentelemetry.api.OpenTelemetryConfig.INSTRUMENTATION_VERSION;
+import static io.smallrye.opentelemetry.implementation.cdi.OpenTelemetryProducer.performPrivileged;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
@@ -35,8 +36,9 @@ public class WithSpanInterceptor {
                 new WithSpanParameterAttributeNamesExtractor(),
                 MethodRequest::getArgs);
 
-        this.instrumenter = builder.addAttributesExtractor(attributesExtractor)
-                .buildInstrumenter(methodRequest -> spanKindFromMethod(methodRequest.getMethod()));
+        this.instrumenter = performPrivileged(() -> builder
+                .addAttributesExtractor(attributesExtractor)
+                .buildInstrumenter(methodRequest -> spanKindFromMethod(methodRequest.getMethod())));
     }
 
     private static SpanKind spanKindFromMethod(Method method) {
@@ -64,7 +66,11 @@ public class WithSpanInterceptor {
             Object result = invocationContext.proceed();
 
             if (shouldStart) {
-                instrumenter.end(spanContext, methodRequest, null, null);
+                final var context = spanContext;
+                performPrivileged(() -> {
+                    instrumenter.end(context, methodRequest, null, null);
+                    return null;
+                });
             }
 
             return result;

--- a/implementation/rest/src/main/java/io/smallrye/opentelemetry/implementation/rest/OpenTelemetryClientFilter.java
+++ b/implementation/rest/src/main/java/io/smallrye/opentelemetry/implementation/rest/OpenTelemetryClientFilter.java
@@ -7,6 +7,8 @@ import static java.util.Collections.singletonList;
 
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.List;
 
 import jakarta.inject.Inject;
@@ -49,13 +51,15 @@ public class OpenTelemetryClientFilter implements ClientRequestFilter, ClientRes
                 HttpSpanNameExtractor.create(clientAttributesExtractor));
         builder.setInstrumentationVersion(INSTRUMENTATION_VERSION);
 
-        this.instrumenter = builder
+        PrivilegedAction<Instrumenter<ClientRequestContext, ClientResponseContext>> func = () -> builder
                 .setSpanStatusExtractor(HttpSpanStatusExtractor.create(clientAttributesExtractor))
                 .addAttributesExtractor(NetworkAttributesExtractor.create(new NetworkAttributesGetter()))
                 .addAttributesExtractor(HttpClientAttributesExtractor.create(clientAttributesExtractor))
                 .addOperationMetrics(HttpClientMetrics.get())
                 .addOperationMetrics(HttpClientExperimentalMetrics.get())
                 .buildClientInstrumenter(new ClientRequestContextTextMapSetter());
+
+        this.instrumenter = (System.getSecurityManager() == null) ? func.run() : AccessController.doPrivileged(func);
     }
 
     @Override

--- a/java.policy
+++ b/java.policy
@@ -1,0 +1,7 @@
+// Grant all permissions so the Security Manager is active but non-restrictive.
+// The goal is to verify the code runs correctly under a Security Manager,
+// not to test a restrictive policy.
+
+grant {
+    permission java.security.AllPermission;
+};

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,32 @@
                 <module>release</module>
             </modules>
         </profile>
+        <profile>
+            <id>with-security-manager</id>
+            <activation>
+                <jdk>(,22]</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>with-security-manager</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <argLine>-Djava.security.manager -Djava.security.policy=${maven.multiModuleProjectDirectory}/java.policy</argLine>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>

--- a/testsuite/extra/src/test/java/io/smallrye/opentelemetry/extra/test/metrics/rest/RestMetricsTest.java
+++ b/testsuite/extra/src/test/java/io/smallrye/opentelemetry/extra/test/metrics/rest/RestMetricsTest.java
@@ -97,10 +97,8 @@ public class RestMetricsTest {
     @Test
     void metrics() {
         given().get("/sub/12").then().statusCode(HTTP_OK);
-        assertNotNull(exporter.getFinishedMetricItem("queueSize"));
         assertNotNull(exporter.getFinishedMetricItem("http.server.request.duration"));
         assertNotNull(exporter.getFinishedMetricItem("http.server.active_requests"));
-        assertNotNull(exporter.getFinishedMetricItem("processedSpans"));
     }
 
     @Path("/")


### PR DESCRIPTION
- Add SpanExporterCustomizer to capture the SpanExporter 
- Add SpanProcessorCustomizer to return SimpleSpanProcessor if SM is detected 
- Wrap SM-sensitive calls in doPrivileged.
- Update examples poms to current otel version

Fixes #585 and #586