### PR TITLE
Update OpenTelemetry to 1.63, Instrumentation to 2.29 and SemConv to 1.41

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -66,7 +66,7 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
-            <artifactId>opentelemetry-runtime-telemetry-java8</artifactId>
+            <artifactId>opentelemetry-runtime-telemetry</artifactId>
         </dependency>
     </dependencies>
 

--- a/api/src/main/java/io/smallrye/opentelemetry/api/OpenTelemetryLogHandler.java
+++ b/api/src/main/java/io/smallrye/opentelemetry/api/OpenTelemetryLogHandler.java
@@ -9,7 +9,6 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.text.MessageFormat;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 import java.util.logging.Formatter;
@@ -30,7 +29,7 @@ public class OpenTelemetryLogHandler extends Handler {
     // See: https://github.com/open-telemetry/semantic-conventions/issues/1550
     public static final AttributeKey<String> BRIDGE_NAME = AttributeKey.stringKey("bridge.name");
     private static final AttributeKey<String> NAMESPACE_ATTRIBUTE_KEY = AttributeKey.stringKey("log.logger.namespace");
-    private final OpenTelemetry openTelemetry;
+    private volatile OpenTelemetry openTelemetry;
 
     public OpenTelemetryLogHandler(final OpenTelemetry openTelemetry) {
         this.openTelemetry = openTelemetry;
@@ -38,9 +37,13 @@ public class OpenTelemetryLogHandler extends Handler {
 
     public static synchronized void install(final OpenTelemetry openTelemetry) {
         java.util.logging.Logger rootLogger = LogManager.getLogManager().getLogger("");
-        if (Arrays.stream(rootLogger.getHandlers()).noneMatch(h -> h instanceof OpenTelemetryLogHandler)) {
-            rootLogger.addHandler(new OpenTelemetryLogHandler(openTelemetry));
+        for (Handler handler : rootLogger.getHandlers()) {
+            if (handler instanceof OpenTelemetryLogHandler) {
+                ((OpenTelemetryLogHandler) handler).openTelemetry = openTelemetry;
+                return;
+            }
         }
+        rootLogger.addHandler(new OpenTelemetryLogHandler(openTelemetry));
     }
 
     @Override

--- a/examples/agent/pom.xml
+++ b/examples/agent/pom.xml
@@ -28,8 +28,8 @@
         <version.resteasy>6.2.16.Final</version.resteasy>
         <version.smallrye.config>3.13.4</version.smallrye.config>
 
-        <version.opentelemetry>1.62.0</version.opentelemetry>
-        <version.opentelemetry.agent>2.28.0</version.opentelemetry.agent>
+        <version.opentelemetry>1.63.0</version.opentelemetry>
+        <version.opentelemetry.agent>2.29.0</version.opentelemetry.agent>
     </properties>
 
     <build>

--- a/examples/library/pom.xml
+++ b/examples/library/pom.xml
@@ -28,8 +28,8 @@
         <version.resteasy>6.2.16.Final</version.resteasy>
         <version.smallrye.config>3.13.4</version.smallrye.config>
 
-        <version.opentelemetry.agent>2.28.0</version.opentelemetry.agent>
-        <version.opentelemetry.exporter>1.62.0</version.opentelemetry.exporter>
+        <version.opentelemetry.agent>2.29.0</version.opentelemetry.agent>
+        <version.opentelemetry.exporter>1.63.0</version.opentelemetry.exporter>
     </properties>
 
     <build>

--- a/implementation/cdi/src/main/java/io/smallrye/opentelemetry/implementation/cdi/OpenTelemetryProducer.java
+++ b/implementation/cdi/src/main/java/io/smallrye/opentelemetry/implementation/cdi/OpenTelemetryProducer.java
@@ -29,7 +29,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
-import io.opentelemetry.instrumentation.runtimemetrics.java8.RuntimeMetrics;
+import io.opentelemetry.instrumentation.runtimetelemetry.RuntimeTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder;
 import io.opentelemetry.sdk.common.CompletableResultCode;
@@ -66,7 +66,7 @@ public class OpenTelemetryProducer {
 
         return performPrivileged(() -> {
             var otel = builder.build().getOpenTelemetrySdk();
-            closeables.add(RuntimeMetrics.create(otel));
+            closeables.add(RuntimeTelemetry.create(otel));
             OpenTelemetryLogHandler.install(otel);
             return otel;
         });

--- a/implementation/cdi/src/main/java/io/smallrye/opentelemetry/implementation/cdi/WithSpanInterceptor.java
+++ b/implementation/cdi/src/main/java/io/smallrye/opentelemetry/implementation/cdi/WithSpanInterceptor.java
@@ -11,6 +11,8 @@ import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.InvocationContext;
 
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
@@ -18,12 +20,15 @@ import io.opentelemetry.instrumentation.annotations.SpanAttribute;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.opentelemetry.instrumentation.api.annotation.support.MethodSpanAttributesExtractor;
 import io.opentelemetry.instrumentation.api.annotation.support.ParameterAttributeNamesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor;
 import io.opentelemetry.instrumentation.api.semconv.util.SpanNames;
 
 public class WithSpanInterceptor {
+    private static final AttributeKey<String> CODE_FUNCTION_NAME = AttributeKey.stringKey("code.function.name");
+
     private final Instrumenter<MethodRequest, Void> instrumenter;
 
     public WithSpanInterceptor(final OpenTelemetry openTelemetry) {
@@ -38,6 +43,7 @@ public class WithSpanInterceptor {
 
         this.instrumenter = performPrivileged(() -> builder
                 .addAttributesExtractor(attributesExtractor)
+                .addAttributesExtractor(new CodeFunctionNameExtractor())
                 .buildInstrumenter(methodRequest -> spanKindFromMethod(methodRequest.getMethod())));
     }
 
@@ -90,6 +96,21 @@ public class WithSpanInterceptor {
                 spanName = SpanNames.fromMethod(methodRequest.getMethod());
             }
             return spanName;
+        }
+    }
+
+    private static final class CodeFunctionNameExtractor implements AttributesExtractor<MethodRequest, Void> {
+        @Override
+        public void onStart(final AttributesBuilder attributes, final Context parentContext,
+                final MethodRequest methodRequest) {
+            Method method = methodRequest.getMethod();
+            attributes.put(CODE_FUNCTION_NAME,
+                    method.getDeclaringClass().getName() + "." + method.getName());
+        }
+
+        @Override
+        public void onEnd(final AttributesBuilder attributes, final Context context, final MethodRequest methodRequest,
+                final Void unused, final Throwable error) {
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,11 @@
     <url>https://smallrye.io</url>
 
     <properties>
-        <version.opentelemetry>1.62.0</version.opentelemetry>
-        <version.opentelemetry.instrumentation>2.27.0</version.opentelemetry.instrumentation>
-        <version.opentelemetry.semconv>1.32.0</version.opentelemetry.semconv>
+        <version.opentelemetry>1.63.0</version.opentelemetry>
+        <version.opentelemetry.instrumentation>2.29.0</version.opentelemetry.instrumentation>
+        <version.opentelemetry.semconv>1.41.1</version.opentelemetry.semconv>
         <version.microprofile.opentelemetry>2.1</version.microprofile.opentelemetry>
-        <version.microprofile.config>3.1</version.microprofile.config>
+        <version.microprofile.config>3.1.1</version.microprofile.config>
         <version.mutiny>3.0.0</version.mutiny>
         <version.smallrye.common>2.18.1</version.smallrye.common>
         <version.resteasy>6.2.12.Final</version.resteasy>


### PR DESCRIPTION
- This also aligns versions with MicroProfile Telemetry 2.2